### PR TITLE
Add repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "bin": {
     "nqm-json-import": "./nqm-json-import.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nqminds/nqm-json-import.git"
+  },
   "author": "toby.ealden@gmail.com",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
This will make it so that people can find [the GitHub repository](https://github.com/nqminds/nqm-json-import/) from [the npmjs page](https://www.npmjs.com/package/nqm-json-import)
